### PR TITLE
Add integration tests for Controllers

### DIFF
--- a/src/test/java/com/mimteam/mimserver/TestingUtils.java
+++ b/src/test/java/com/mimteam/mimserver/TestingUtils.java
@@ -2,10 +2,17 @@ package com.mimteam.mimserver;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.mimteam.mimserver.model.entities.UserEntity;
+import com.mimteam.mimserver.model.entities.chat.ChatEntity;
+import com.mimteam.mimserver.model.entities.chat.UserToChatEntity;
+import com.mimteam.mimserver.model.entities.chat.UserToChatId;
 import com.mimteam.mimserver.model.responses.ResponseBuilder;
 import com.mimteam.mimserver.model.responses.ResponseDTO;
 import org.mockito.Mockito;
 import org.springframework.http.ResponseEntity;
+import org.springframework.test.web.servlet.MvcResult;
+
+import java.io.UnsupportedEncodingException;
 
 public class TestingUtils {
     public static String convertToString(Object object) throws JsonProcessingException {
@@ -36,5 +43,19 @@ public class TestingUtils {
         ResponseBuilder responseBuilder = createEmptySuccessResponseBuilder();
         Mockito.when(responseBuilder.stringBody(Mockito.anyString())).thenReturn(responseBuilder);
         return responseBuilder;
+    }
+
+    public static ResponseDTO parseResponseDto(MvcResult mvcResult)
+            throws UnsupportedEncodingException, JsonProcessingException {
+        ObjectMapper objectMapper = new ObjectMapper();
+        return objectMapper.readValue(mvcResult.getResponse().getContentAsString(), ResponseDTO.class);
+    }
+
+    public static UserToChatEntity buildUserToChatEntity(UserEntity userEntity, ChatEntity chatEntity) {
+        UserToChatId userToChatId = new UserToChatId(userEntity.getUserId(), chatEntity.getChatId());
+        UserToChatEntity userToChatEntity = new UserToChatEntity(userToChatId);
+        userToChatEntity.setUserEntity(userEntity);
+        userToChatEntity.setChatEntity(chatEntity);
+        return userToChatEntity;
     }
 }

--- a/src/test/java/com/mimteam/mimserver/controllers/ChatControllerTest.java
+++ b/src/test/java/com/mimteam/mimserver/controllers/ChatControllerTest.java
@@ -1,18 +1,16 @@
 package com.mimteam.mimserver.controllers;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
 
 import com.mimteam.mimserver.TestingUtils;
 import com.mimteam.mimserver.events.ChatMembershipEvent;
 import com.mimteam.mimserver.handlers.EventHandler;
 import com.mimteam.mimserver.model.dto.ChatDTO;
 import com.mimteam.mimserver.model.dto.MessageDTO;
+import com.mimteam.mimserver.model.dto.UserDTO;
 import com.mimteam.mimserver.model.entities.UserEntity;
 import com.mimteam.mimserver.model.entities.chat.ChatEntity;
 import com.mimteam.mimserver.model.entities.chat.ChatMessageEntity;
-import com.mimteam.mimserver.model.entities.chat.UserToChatEntity;
-import com.mimteam.mimserver.model.entities.chat.UserToChatId;
 import com.mimteam.mimserver.model.messages.ChatMembershipMessage;
 import com.mimteam.mimserver.model.messages.TextMessage;
 import com.mimteam.mimserver.model.responses.ResponseDTO;
@@ -38,7 +36,6 @@ import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
 
-import java.io.UnsupportedEncodingException;
 import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -68,6 +65,7 @@ class ChatControllerTest {
     private static final String USER_UUID_TOKEN = "00000000-0000-0000-0000-000000000000";
     private static final String AUTHORIZATION_HEADER_TOKEN = "Bearer " + USER_UUID_TOKEN;
 
+    private static final String CHAT_NAME = "Test Chat";
     private static final String USER_NAME = "Test User";
     private static final String INVITATION_KEY = "abcd1234";
 
@@ -93,6 +91,7 @@ class ChatControllerTest {
         chatMessageEntity2.setContent(CONTENT_2);
 
         chatEntity = new ChatEntity();
+        chatEntity.setName(CHAT_NAME);
         chatEntity.setInvitationKey(INVITATION_KEY);
 
         userEntity = new UserEntity(USER_NAME, LOGIN, PASSWORD);
@@ -109,6 +108,26 @@ class ChatControllerTest {
     }
 
     @Test
+    public void createChatSuccess() throws Exception {
+        chatEntity.setChatId(2);
+
+        MvcResult result = mockMvc.perform(MockMvcRequestBuilders.post("/chats/create")
+                .param("chatName", CHAT_NAME)
+                .header(HttpHeaders.AUTHORIZATION, AUTHORIZATION_HEADER_TOKEN))
+                .andExpect(MockMvcResultMatchers.status().is2xxSuccessful())
+                .andReturn();
+        ResponseDTO responseDto = TestingUtils.parseResponseDto(result);
+
+        Assertions.assertEquals(ResponseDTO.ResponseType.OK, responseDto.getResponseType());
+        Assertions.assertNotNull(responseDto.getResponseMessage());
+        Assertions.assertEquals(TestingUtils.convertToString(new ChatDTO(chatEntity)),
+                responseDto.getResponseMessage());
+
+        Assertions.assertEquals(1, chatsRepository.count());
+        Assertions.assertEquals(1, usersToChatsRepository.count());
+    }
+
+    @Test
     public void joinChatNotExists() throws Exception {
         MvcResult result = mockMvc.perform(MockMvcRequestBuilders.post("/chats/join")
                 .param("invitationKey", INVITATION_KEY)
@@ -116,7 +135,7 @@ class ChatControllerTest {
                 .andExpect(MockMvcResultMatchers.status().is4xxClientError())
                 .andReturn();
 
-        ResponseDTO responseDto = parseResponseDto(result);
+        ResponseDTO responseDto = TestingUtils.parseResponseDto(result);
 
         Assertions.assertEquals(ResponseDTO.ResponseType.CHAT_NOT_EXISTS, responseDto.getResponseType());
         Assertions.assertNull(responseDto.getResponseMessage());
@@ -127,16 +146,15 @@ class ChatControllerTest {
 
     @Test
     public void joinChatUserAlreadyInChat() throws Exception {
-        usersRepository.save(userEntity);
         chatsRepository.save(chatEntity);
-        usersToChatsRepository.save(buildUserToChatEntity(userEntity, chatEntity));
+        usersToChatsRepository.save(TestingUtils.buildUserToChatEntity(userEntity, chatEntity));
 
         MvcResult result = mockMvc.perform(MockMvcRequestBuilders.post("/chats/join")
                 .param("invitationKey", INVITATION_KEY)
                 .header(HttpHeaders.AUTHORIZATION, AUTHORIZATION_HEADER_TOKEN))
                 .andExpect(MockMvcResultMatchers.status().is4xxClientError())
                 .andReturn();
-        ResponseDTO responseDto = parseResponseDto(result);
+        ResponseDTO responseDto = TestingUtils.parseResponseDto(result);
 
         Assertions.assertEquals(ResponseDTO.ResponseType.USER_ALREADY_IN_CHAT, responseDto.getResponseType());
         Assertions.assertNull(responseDto.getResponseMessage());
@@ -153,11 +171,12 @@ class ChatControllerTest {
                 .header(HttpHeaders.AUTHORIZATION, AUTHORIZATION_HEADER_TOKEN))
                 .andExpect(MockMvcResultMatchers.status().is2xxSuccessful())
                 .andReturn();
-        ResponseDTO responseDto = parseResponseDto(result);
+        ResponseDTO responseDto = TestingUtils.parseResponseDto(result);
 
         Assertions.assertEquals(ResponseDTO.ResponseType.OK, responseDto.getResponseType());
         Assertions.assertNotNull(responseDto.getResponseMessage());
-        Assertions.assertEquals(TestingUtils.convertToString(new ChatDTO(chatEntity)), responseDto.getResponseMessage());
+        Assertions.assertEquals(TestingUtils.convertToString(new ChatDTO(chatEntity)),
+                responseDto.getResponseMessage());
 
         ArgumentCaptor<ChatMembershipEvent> chatEventCaptor = ArgumentCaptor.forClass(ChatMembershipEvent.class);
         Mockito.verify(eventHandler).post(chatEventCaptor.capture());
@@ -170,13 +189,126 @@ class ChatControllerTest {
     }
 
     @Test
+    public void leaveChatUserNotInChat() throws Exception {
+        chatsRepository.save(chatEntity);
+
+        MvcResult result = mockMvc.perform(MockMvcRequestBuilders.post("/chats/" + chatEntity.getChatId() + "/leave")
+                .header(HttpHeaders.AUTHORIZATION, AUTHORIZATION_HEADER_TOKEN))
+                .andExpect(MockMvcResultMatchers.status().is4xxClientError())
+                .andReturn();
+        ResponseDTO responseDto = TestingUtils.parseResponseDto(result);
+
+        Assertions.assertEquals(ResponseDTO.ResponseType.USER_NOT_IN_CHAT, responseDto.getResponseType());
+        Assertions.assertNull(responseDto.getResponseMessage());
+
+        Mockito.verify(eventHandler, Mockito.never()).post(Mockito.any());
+        Assertions.assertEquals(0, usersToChatsRepository.count());
+    }
+
+    @Test
+    public void leaveChatSuccess() throws Exception {
+        chatsRepository.save(chatEntity);
+        usersToChatsRepository.save(TestingUtils.buildUserToChatEntity(userEntity, chatEntity));
+
+        MvcResult result = mockMvc.perform(MockMvcRequestBuilders.post("/chats/" + chatEntity.getChatId() + "/leave")
+                .header(HttpHeaders.AUTHORIZATION, AUTHORIZATION_HEADER_TOKEN))
+                .andExpect(MockMvcResultMatchers.status().is2xxSuccessful())
+                .andReturn();
+        ResponseDTO responseDto = TestingUtils.parseResponseDto(result);
+
+        Assertions.assertEquals(ResponseDTO.ResponseType.OK, responseDto.getResponseType());
+        Assertions.assertNull(responseDto.getResponseMessage());
+
+        ArgumentCaptor<ChatMembershipEvent> chatEventCaptor = ArgumentCaptor.forClass(ChatMembershipEvent.class);
+        Mockito.verify(eventHandler).post(chatEventCaptor.capture());
+
+        Assertions.assertEquals(userEntity.getUserId(), chatEventCaptor.getValue().getUserId());
+        Assertions.assertEquals(chatEntity.getChatId(), chatEventCaptor.getValue().getChatId());
+        Assertions.assertEquals(ChatMembershipMessage.ChatMembershipMessageType.LEAVE,
+                chatEventCaptor.getValue().getChatMembershipMessageType());
+        Assertions.assertEquals(0, usersToChatsRepository.count());
+    }
+
+    @Test
+    public void getUserListChatNotExists() throws Exception {
+        MvcResult result = mockMvc.perform(MockMvcRequestBuilders.get("/chats/1/userlist")
+                .header(HttpHeaders.AUTHORIZATION, AUTHORIZATION_HEADER_TOKEN))
+                .andExpect(MockMvcResultMatchers.status().is4xxClientError())
+                .andReturn();
+        ResponseDTO responseDTO = TestingUtils.parseResponseDto(result);
+
+        Assertions.assertEquals(ResponseDTO.ResponseType.CHAT_NOT_EXISTS, responseDTO.getResponseType());
+        Assertions.assertNull(responseDTO.getResponseMessage());
+    }
+
+    @Test
+    public void getUserListEmpty() throws Exception {
+        chatsRepository.save(chatEntity);
+
+        MvcResult result = mockMvc.perform(MockMvcRequestBuilders.get("/chats/" + chatEntity.getChatId() + "/userlist")
+                .header(HttpHeaders.AUTHORIZATION, AUTHORIZATION_HEADER_TOKEN))
+                .andExpect(MockMvcResultMatchers.status().is2xxSuccessful())
+                .andReturn();
+        ResponseDTO responseDTO = TestingUtils.parseResponseDto(result);
+
+        Assertions.assertEquals(ResponseDTO.ResponseType.OK, responseDTO.getResponseType());
+        Assertions.assertEquals("[]", responseDTO.getResponseMessage());
+    }
+
+    @Test
+    public void getChatListSuccess() throws Exception {
+        chatsRepository.save(chatEntity);
+        usersToChatsRepository.save(TestingUtils.buildUserToChatEntity(userEntity, chatEntity));
+
+        MvcResult result = mockMvc.perform(MockMvcRequestBuilders.get("/chats/" + chatEntity.getChatId() + "/userlist")
+                .header(HttpHeaders.AUTHORIZATION, AUTHORIZATION_HEADER_TOKEN))
+                .andExpect(MockMvcResultMatchers.status().is2xxSuccessful())
+                .andReturn();
+        ResponseDTO responseDTO = TestingUtils.parseResponseDto(result);
+
+        Assertions.assertEquals(ResponseDTO.ResponseType.OK, responseDTO.getResponseType());
+        Assertions.assertEquals("[" + TestingUtils.convertToString(new UserDTO(userEntity)) + "]",
+                responseDTO.getResponseMessage());
+    }
+
+    @Test
+    public void getInvitationKeyUserNotInChat() throws Exception {
+        MvcResult result = mockMvc.perform(MockMvcRequestBuilders.get("/chats/" + chatId + "/invitation")
+                .header(HttpHeaders.AUTHORIZATION, AUTHORIZATION_HEADER_TOKEN))
+                .andExpect(MockMvcResultMatchers.status().is4xxClientError())
+                .andReturn();
+
+        ResponseDTO responseDto = TestingUtils.parseResponseDto(result);
+
+        Assertions.assertEquals(ResponseDTO.ResponseType.USER_NOT_IN_CHAT, responseDto.getResponseType());
+        Assertions.assertNull(responseDto.getResponseMessage());
+    }
+
+    @Test
+    public void getInvitationKeySuccess() throws Exception {
+        chatsRepository.save(chatEntity);
+        usersToChatsRepository.save(TestingUtils.buildUserToChatEntity(userEntity, chatEntity));
+
+        MvcResult result =
+                mockMvc.perform(MockMvcRequestBuilders.get("/chats/" + chatEntity.getChatId() + "/invitation")
+                        .header(HttpHeaders.AUTHORIZATION, AUTHORIZATION_HEADER_TOKEN))
+                        .andExpect(MockMvcResultMatchers.status().is2xxSuccessful())
+                        .andReturn();
+
+        ResponseDTO responseDto = TestingUtils.parseResponseDto(result);
+
+        Assertions.assertEquals(ResponseDTO.ResponseType.OK, responseDto.getResponseType());
+        Assertions.assertNotNull(responseDto.getResponseMessage());
+    }
+
+    @Test
     public void getMessageHistoryChatNotExists() throws Exception {
         MvcResult result = mockMvc.perform(MockMvcRequestBuilders.get("/chats/2/messages")
                 .header(HttpHeaders.AUTHORIZATION, AUTHORIZATION_HEADER_TOKEN))
                 .andExpect(MockMvcResultMatchers.status().is4xxClientError())
                 .andReturn();
 
-        ResponseDTO responseDto = parseResponseDto(result);
+        ResponseDTO responseDto = TestingUtils.parseResponseDto(result);
 
         Assertions.assertEquals(ResponseDTO.ResponseType.CHAT_NOT_EXISTS, responseDto.getResponseType());
         Assertions.assertNull(responseDto.getResponseMessage());
@@ -192,7 +324,7 @@ class ChatControllerTest {
                 .andExpect(MockMvcResultMatchers.status().is2xxSuccessful())
                 .andReturn();
 
-        ResponseDTO responseDto = parseResponseDto(result);
+        ResponseDTO responseDto = TestingUtils.parseResponseDto(result);
 
         Assertions.assertEquals(ResponseDTO.ResponseType.OK, responseDto.getResponseType());
         Assertions.assertNotNull(responseDto.getResponseMessage());
@@ -212,7 +344,7 @@ class ChatControllerTest {
                 .header(HttpHeaders.AUTHORIZATION, AUTHORIZATION_HEADER_TOKEN))
                 .andExpect(MockMvcResultMatchers.status().is2xxSuccessful())
                 .andReturn();
-        ResponseDTO responseDto = parseResponseDto(result);
+        ResponseDTO responseDto = TestingUtils.parseResponseDto(result);
 
         Assertions.assertEquals(ResponseDTO.ResponseType.OK, responseDto.getResponseType());
         Assertions.assertNotNull(responseDto.getResponseMessage());
@@ -222,42 +354,6 @@ class ChatControllerTest {
         Assertions.assertEquals(expectedResponseMessage, responseDto.getResponseMessage());
     }
 
-    @Test
-    public void getInvitationKeyUserNotInChat() throws Exception {
-        MvcResult result = mockMvc.perform(MockMvcRequestBuilders.get("/chats/" + chatId + "/invitation")
-                .header(HttpHeaders.AUTHORIZATION, AUTHORIZATION_HEADER_TOKEN))
-                .andExpect(MockMvcResultMatchers.status().is4xxClientError())
-                .andReturn();
-
-        ResponseDTO responseDto = parseResponseDto(result);
-
-        Assertions.assertEquals(ResponseDTO.ResponseType.USER_NOT_IN_CHAT, responseDto.getResponseType());
-        Assertions.assertNull(responseDto.getResponseMessage());
-    }
-
-    @Test
-    public void getInvitationKeySuccess() throws Exception {
-        chatsRepository.save(chatEntity);
-        usersToChatsRepository.save(buildUserToChatEntity(userEntity, chatEntity));
-
-        MvcResult result =
-                mockMvc.perform(MockMvcRequestBuilders.get("/chats/" + chatEntity.getChatId() + "/invitation")
-                .header(HttpHeaders.AUTHORIZATION, AUTHORIZATION_HEADER_TOKEN))
-                .andExpect(MockMvcResultMatchers.status().is2xxSuccessful())
-                .andReturn();
-
-        ResponseDTO responseDto = parseResponseDto(result);
-
-        Assertions.assertEquals(ResponseDTO.ResponseType.OK, responseDto.getResponseType());
-        Assertions.assertNotNull(responseDto.getResponseMessage());
-    }
-
-    private ResponseDTO parseResponseDto(MvcResult mvcResult)
-            throws UnsupportedEncodingException, JsonProcessingException {
-        ObjectMapper objectMapper = new ObjectMapper();
-        return objectMapper.readValue(mvcResult.getResponse().getContentAsString(), ResponseDTO.class);
-    }
-
     private String chatMessageEntitiesToDtoString(List<ChatMessageEntity> chatMessageEntities)
             throws JsonProcessingException {
         List<MessageDTO> dtoList = chatMessageEntities.stream()
@@ -265,13 +361,5 @@ class ChatControllerTest {
                 .map(TextMessage::toDataTransferObject)
                 .collect(Collectors.toList());
         return TestingUtils.convertToString(dtoList);
-    }
-
-    private UserToChatEntity buildUserToChatEntity(UserEntity userEntity, ChatEntity chatEntity) {
-        UserToChatId userToChatId = new UserToChatId(userEntity.getUserId(), chatEntity.getChatId());
-        UserToChatEntity userToChatEntity = new UserToChatEntity(userToChatId);
-        userToChatEntity.setUserEntity(userEntity);
-        userToChatEntity.setChatEntity(chatEntity);
-        return userToChatEntity;
     }
 }

--- a/src/test/resources/application-test.properties
+++ b/src/test/resources/application-test.properties
@@ -1,4 +1,4 @@
 spring.datasource.driver-class-name=org.h2.Driver
-spring.datasource.url=jdbc:h2:mem:db;DB_CLOSE_DELAY=-1;MODE=PostgreSQL;INIT=CREATE SCHEMA IF NOT EXISTS mim
+spring.datasource.url=jdbc:h2:mem:db;DB_CLOSE_DELAY=-1;MODE=PostgreSQL
 spring.datasource.username=sa
 spring.datasource.password=sa


### PR DESCRIPTION
Добавлены интеграционные тесты для ChatController. В них проверяются все
HTTP-запросы, поступающие в этот контроллер.
При тестировании контроллера используется база данных, которая создается
прямо в памяти.